### PR TITLE
add default for end dates for experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ Python tool to validate JSON resumes to ensure that they are according to the [d
 $ pip install jsonresume-validator
 ```
 
-## Example uses
+## Example apps
+
+- A sample Flask web app to [validate an uploaded JSON resume and returning validation issues on submission](https://github.com/kelvintaywl/jsonresume-server)
+
+## Example codes
 
 1. Using Resume class
 

--- a/jsonresume/__init__.py
+++ b/jsonresume/__init__.py
@@ -7,6 +7,6 @@
 
 from jsonresume.resume import Resume
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 __all__ = ['Resume']

--- a/jsonresume/schema/components/experience.py
+++ b/jsonresume/schema/components/experience.py
@@ -5,7 +5,7 @@ import colander
 
 class Experience(colander.MappingSchema):
     startDate = colander.SchemaNode(colander.Date())
-    endDate = colander.SchemaNode(colander.Date())
+    endDate = colander.SchemaNode(colander.Date(), missing=None)
 
 
 class Highlights(colander.SequenceSchema):

--- a/jsonresume/tests/fixtures/resumes/valid/resume.json
+++ b/jsonresume/tests/fixtures/resumes/valid/resume.json
@@ -33,7 +33,6 @@
       "position": "Software Engineer",
       "website": "https://gengo.com",
       "startDate": "2014-10-17",
-      "endDate": "2016-12-31",
       "summary": "I'm learning new things everyday as I work on internal-facing applications and tools used by Sales, Finance and Operations team, as well as client-facing applications. I also maintain API clients and style guides and open-source projects for Gengo.",
       "highlights": [
         "Self-initiated tools to help manage crons ",

--- a/setup.py
+++ b/setup.py
@@ -15,12 +15,12 @@ extras_require = {
 }
 
 setup(name='jsonresume-validator',
-      version='0.1.0',
+      version='0.1.1',
       description='validates JSON resumes',
       author='Kelvin Tay',
       author_email='kelvintay@gmail.com',
       url='https://github.com/kelvintaywl/jsonresume-validator',
-      download_url='https://github.com/kelvintaywl/jsonresume-validator/tarball/0.1.0',
+      download_url='https://github.com/kelvintaywl/jsonresume-validator/tarball/0.1.1',
       keywords='jsonresume, validation, colander',
       packages=find_packages(),
       include_package_data=True,


### PR DESCRIPTION
This PR ensures that experience-related modules (i.e. work experience) does not need a strict non-empty endDate value.

Also added example link to sample Flask app.
