### PR TITLE
[0.1.2][update] make urls optional in schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Change Log
 
 ## [Unreleased]
+
+## [0.1.2] - 2016-06-04
 ### Changed
 - made end dates not compulsory / required (e.g., in work experiences)
+- made urls not coompulsory / required
 
 ## [0.1.1] - 2016-05-27
 ### Added

--- a/jsonresume/exceptions.py
+++ b/jsonresume/exceptions.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import colander
 
-
-class InvalidResumeError(colander.Invalid):
+class InvalidResumeError(Exception):
     """ Raised when a JSON resume (as python object) has invalid schema """
+    pass

--- a/jsonresume/schema/components/experience.py
+++ b/jsonresume/schema/components/experience.py
@@ -20,7 +20,7 @@ class Work(Experience):
     company = colander.SchemaNode(colander.String())
     position = colander.SchemaNode(colander.String())
     summary = colander.SchemaNode(colander.String())
-    website = colander.SchemaNode(colander.String(), validator=colander.url)
+    website = colander.SchemaNode(colander.String(), validator=colander.url, missing=None)
     highlights = Highlights()
 
 
@@ -28,7 +28,7 @@ class Volunteer(Experience):
     organization = colander.SchemaNode(colander.String())
     position = colander.SchemaNode(colander.String())
     summary = colander.SchemaNode(colander.String())
-    website = colander.SchemaNode(colander.String(), validator=colander.url)
+    website = colander.SchemaNode(colander.String(), validator=colander.url, missing=None)
     highlights = Highlights()
 
 

--- a/jsonresume/schema/components/personal.py
+++ b/jsonresume/schema/components/personal.py
@@ -9,7 +9,7 @@ from jsonresume.schema.validators import is_valid_country_code
 class Profile(colander.MappingSchema):
     network = colander.SchemaNode(colander.String())
     username = colander.SchemaNode(colander.String())
-    url = colander.SchemaNode(colander.String(), validator=colander.url)
+    url = colander.SchemaNode(colander.String(), validator=colander.url, missing=None)
 
 
 class Profiles(colander.SequenceSchema):
@@ -39,7 +39,7 @@ class BasicInfo(colander.MappingSchema):
     picture = colander.SchemaNode(colander.String(), validator=colander.url, missing=None)
     email = colander.SchemaNode(colander.String(), validator=colander.Email())
     phone = colander.SchemaNode(colander.String())
-    website = colander.SchemaNode(colander.String(), validator=colander.url)
+    website = colander.SchemaNode(colander.String(), validator=colander.url, missing=None)
     summary = colander.SchemaNode(colander.String())
     location = Location()
     profiles = Profiles()

--- a/jsonresume/tests/fixtures/resumes/invalid/invalid_urls.json
+++ b/jsonresume/tests/fixtures/resumes/invalid/invalid_urls.json
@@ -1,0 +1,128 @@
+{
+  "basics": {
+    "name": "Dr. Foo Bar",
+    "label": "Programmer",
+    "picture": "",
+    "email": "drorata@gmail.com",
+    "phone": "(912) 555-4321",
+    "website": "http://richardhendricks.com",
+    "summary": "Richard hails from Tulsa. He has earned degrees from the University of Oklahoma and Stanford. (Go Sooners and Cardinals!) Before starting Pied Piper, he worked for Hooli as a part time software developer. While his work focuses on applied information theory, mostly optimizing lossless compression schema of both the length-limited and adaptive variants, his non-work interests range widely, everything from quantum computing to chaos theory. He could tell you about it, but THAT would NOT be a “length-limited” conversation!",
+    "location": {
+      "address": "2712 Broadway St",
+      "postalCode": "CA 94115",
+      "city": "San Francisco",
+      "countryCode": "US",
+      "region": "California"
+    },
+    "profiles": [
+      {
+        "network": "Twitter",
+        "username": "neutralthoughts",
+        "url": "not a URL, man"
+      },
+      {
+        "network": "SoundCloud",
+        "username": "dandymusicnl",
+        "url": "https://soundcloud.com/dandymusicnl"
+      }
+    ]
+  },
+  "work": [
+    {
+      "company": "Pied Piper",
+      "position": "CEO/President",
+      "startDate": "2013-12-01",
+      "endDate": "2014-12-01",
+      "summary": "Pied Piper is a multi-platform technology based on a proprietary universal compression algorithm that has consistently fielded high Weisman Scores™ that are not merely competitive, but approach the theoretical limit of lossless compression.",
+      "highlights": [
+        "Build an algorithm for artist to detect if their music was violating copy right infringement laws",
+        "Successfully won Techcrunch Disrupt",
+        "Optimized an algorithm that holds the current world record for Weisman Scores"
+      ]
+    }
+  ],
+  "volunteer": [
+    {
+      "organization": "CoderDojo",
+      "position": "Teacher",
+      "startDate": "2012-01-01",
+      "endDate": "2013-01-01",
+      "summary": "Global movement of free coding clubs for young people.",
+      "highlights": [
+        "Awarded 'Teacher of the Month'"
+      ]
+    }
+  ],
+  "education": [
+    {
+      "institution": "University of Oklahoma",
+      "area": "Information Technology",
+      "studyType": "Bachelor",
+      "startDate": "2011-06-01",
+      "endDate": "2014-01-01",
+      "gpa": "4.0",
+      "courses": [
+        "DB1101 - Basic SQL",
+        "CS2011 - Java Introduction"
+      ]
+    }
+  ],
+  "awards": [
+    {
+      "title": "Digital Compression Pioneer Award",
+      "date": "2014-11-01",
+      "awarder": "Techcrunch",
+      "summary": "There is no spoon."
+    }
+  ],
+  "publications": [
+    {
+      "name": "Video compression for 3d media",
+      "publisher": "Hooli",
+      "releaseDate": "2014-10-01",
+      "website": "http://en.wikipedia.org/wiki/Silicon_Valley_(TV_series)",
+      "summary": "Innovative middle-out compression algorithm that changes the way we store data."
+    }
+  ],
+  "skills": [
+    {
+      "name": "Web Development",
+      "level": "Master",
+      "keywords": [
+        "HTML",
+        "CSS",
+        "Javascript"
+      ]
+    },
+    {
+      "name": "Compression",
+      "level": "Master",
+      "keywords": [
+        "Mpeg",
+        "MP4",
+        "GIF"
+      ]
+    }
+  ],
+  "languages": [
+    {
+      "language": "English",
+      "fluency": "Native speaker"
+    }
+  ],
+  "interests": [
+    {
+      "name": "Wildlife",
+      "keywords": [
+        "Ferrets",
+        "Unicorns"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "name": "Erlich Bachman",
+      "reference": "It is my pleasure to recommend Richard, his performance working as a consultant for Main St. Company proved that he will be a valuable addition to any company."
+    }
+  ]
+}

--- a/jsonresume/tests/fixtures/resumes/valid/drorata_sample.json
+++ b/jsonresume/tests/fixtures/resumes/valid/drorata_sample.json
@@ -1,0 +1,128 @@
+{
+  "basics": {
+    "name": "Dr. Foo Bar",
+    "label": "Programmer",
+    "picture": "",
+    "email": "drorata@gmail.com",
+    "phone": "(912) 555-4321",
+    "website": "http://richardhendricks.com",
+    "summary": "Richard hails from Tulsa. He has earned degrees from the University of Oklahoma and Stanford. (Go Sooners and Cardinals!) Before starting Pied Piper, he worked for Hooli as a part time software developer. While his work focuses on applied information theory, mostly optimizing lossless compression schema of both the length-limited and adaptive variants, his non-work interests range widely, everything from quantum computing to chaos theory. He could tell you about it, but THAT would NOT be a “length-limited” conversation!",
+    "location": {
+      "address": "2712 Broadway St",
+      "postalCode": "CA 94115",
+      "city": "San Francisco",
+      "countryCode": "US",
+      "region": "California"
+    },
+    "profiles": [
+      {
+        "network": "Twitter",
+        "username": "neutralthoughts",
+        "url": ""
+      },
+      {
+        "network": "SoundCloud",
+        "username": "dandymusicnl",
+        "url": "https://soundcloud.com/dandymusicnl"
+      }
+    ]
+  },
+  "work": [
+    {
+      "company": "Pied Piper",
+      "position": "CEO/President",
+      "startDate": "2013-12-01",
+      "endDate": "2014-12-01",
+      "summary": "Pied Piper is a multi-platform technology based on a proprietary universal compression algorithm that has consistently fielded high Weisman Scores™ that are not merely competitive, but approach the theoretical limit of lossless compression.",
+      "highlights": [
+        "Build an algorithm for artist to detect if their music was violating copy right infringement laws",
+        "Successfully won Techcrunch Disrupt",
+        "Optimized an algorithm that holds the current world record for Weisman Scores"
+      ]
+    }
+  ],
+  "volunteer": [
+    {
+      "organization": "CoderDojo",
+      "position": "Teacher",
+      "startDate": "2012-01-01",
+      "endDate": "2013-01-01",
+      "summary": "Global movement of free coding clubs for young people.",
+      "highlights": [
+        "Awarded 'Teacher of the Month'"
+      ]
+    }
+  ],
+  "education": [
+    {
+      "institution": "University of Oklahoma",
+      "area": "Information Technology",
+      "studyType": "Bachelor",
+      "startDate": "2011-06-01",
+      "endDate": "2014-01-01",
+      "gpa": "4.0",
+      "courses": [
+        "DB1101 - Basic SQL",
+        "CS2011 - Java Introduction"
+      ]
+    }
+  ],
+  "awards": [
+    {
+      "title": "Digital Compression Pioneer Award",
+      "date": "2014-11-01",
+      "awarder": "Techcrunch",
+      "summary": "There is no spoon."
+    }
+  ],
+  "publications": [
+    {
+      "name": "Video compression for 3d media",
+      "publisher": "Hooli",
+      "releaseDate": "2014-10-01",
+      "website": "http://en.wikipedia.org/wiki/Silicon_Valley_(TV_series)",
+      "summary": "Innovative middle-out compression algorithm that changes the way we store data."
+    }
+  ],
+  "skills": [
+    {
+      "name": "Web Development",
+      "level": "Master",
+      "keywords": [
+        "HTML",
+        "CSS",
+        "Javascript"
+      ]
+    },
+    {
+      "name": "Compression",
+      "level": "Master",
+      "keywords": [
+        "Mpeg",
+        "MP4",
+        "GIF"
+      ]
+    }
+  ],
+  "languages": [
+    {
+      "language": "English",
+      "fluency": "Native speaker"
+    }
+  ],
+  "interests": [
+    {
+      "name": "Wildlife",
+      "keywords": [
+        "Ferrets",
+        "Unicorns"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "name": "Erlich Bachman",
+      "reference": "It is my pleasure to recommend Richard, his performance working as a consultant for Main St. Company proved that he will be a valuable addition to any company."
+    }
+  ]
+}

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ extras_require = {
 }
 
 setup(name='jsonresume-validator',
-      version='0.1.1',
+      version='0.1.2',
       description='validates JSON resumes',
       author='Kelvin Tay',
       author_email='kelvintay@gmail.com',


### PR DESCRIPTION
resolves: https://github.com/kelvintaywl/jsonresume-validator/issues/5

This PR updates the schema attributes such that url-related attributes such as `url`, `website` can be empty / optional values.
### todo
- [x] update schema to allow non-compulsory for url-related attributes
- [x] use sample JSON raised in issue above
- [x] push to PyPI (version 0.1.2)
